### PR TITLE
If `osc` raises an exception, pretend it is not there

### DIFF
--- a/osctiny/utils/conf.py
+++ b/osctiny/utils/conf.py
@@ -16,6 +16,7 @@ from http.cookiejar import LWPCookieJar
 import os
 from pathlib import Path
 
+# pylint: disable=import-error,bare-except,invalid-name
 try:
     from osc import conf as _conf
     from osc.oscerr import ConfigError, ConfigMissingApiurl

--- a/osctiny/utils/conf.py
+++ b/osctiny/utils/conf.py
@@ -19,7 +19,7 @@ from pathlib import Path
 try:
     from osc import conf as _conf
     from osc.oscerr import ConfigError, ConfigMissingApiurl
-except ImportError:
+except:
     _conf = None
 
 


### PR DESCRIPTION
Instead of handling only `ImportError`s due to `osc` not being present, it is a good idea to catch all exceptions that might be raised by `osc`, too, and consider `osc` is not installed.

Inspired by https://github.com/openSUSE/osc/issues/1503