### PR TITLE
osctiny.models.request.Target model: add an optional 'repository' attribute (fixes #183)

### DIFF
--- a/osctiny/models/request.py
+++ b/osctiny/models/request.py
@@ -60,6 +60,7 @@ class Target(typing.NamedTuple):
     project: str
     package: typing.Optional[str] = None
     releaseproject: typing.Optional[str] = None
+    repository: typing.Optional[str] = None
 
     def asxml(self) -> ObjectifiedElement:
         return E.target(**{field: getattr(self, field)

--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -476,6 +476,31 @@ class TestRequest(OscTest):
                 b"</request>",
             )
 
+        with self.subTest(
+            "XML content, target with optional repository"
+        ), mock.patch.object(
+            self.osc.session, "send", return_value=mock_response
+        ) as mock_session:
+            self.osc.requests.create(
+                actions=[
+                    Action(
+                        type=ActionType.RELEASE,
+                        target=Target(
+                            project="Foo:Bar", package="p", repository="images"
+                        ),
+                    )
+                ]
+            )
+            self.assertEqual(
+                mock_session.call_args[0][0].body,
+                b"<?xml version='1.0' encoding='utf-8'?>\n"
+                b"<request>"
+                b'<action type="release">'
+                b'<target project="Foo:Bar" package="p" repository="images"/>'
+                b"</action>"
+                b"</request>",
+            )
+
     @responses.activate
     def test_get_list(self):
         response = self.osc.requests.get_list()


### PR DESCRIPTION
closes #183 