### PR TITLE
osctiny.models.request.Target model: make the 'package' attribute optional (fixes #185)

### DIFF
--- a/osctiny/models/request.py
+++ b/osctiny/models/request.py
@@ -58,7 +58,7 @@ class Target(typing.NamedTuple):
     Target for an action
     """
     project: str
-    package: str
+    package: typing.Optional[str] = None
     releaseproject: typing.Optional[str] = None
 
     def asxml(self) -> ObjectifiedElement:

--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -455,6 +455,26 @@ class TestRequest(OscTest):
                 b'</request>'
             )
 
+        with self.subTest("XML content, target with no package"), mock.patch.object(
+            self.osc.session, "send", return_value=mock_response
+        ) as mock_session:
+            self.osc.requests.create(
+                actions=[
+                    Action(
+                        type=ActionType.RELEASE,
+                        target=Target(project="Foo:Bar"),
+                    )
+                ]
+            )
+            self.assertEqual(
+                mock_session.call_args[0][0].body,
+                b"<?xml version='1.0' encoding='utf-8'?>\n"
+                b"<request>"
+                b'<action type="release">'
+                b'<target project="Foo:Bar"/>'
+                b"</action>"
+                b"</request>",
+            )
 
     @responses.activate
     def test_get_list(self):


### PR DESCRIPTION
closes #185 