### PR TITLE
osctiny.models.request.Source model: add an optional 'repository' attribute (fixes #190)

### DIFF
--- a/osctiny/models/request.py
+++ b/osctiny/models/request.py
@@ -46,6 +46,7 @@ class Source(typing.NamedTuple):
     project: str
     package: str
     rev: typing.Optional[str] = None
+    repository: typing.Optional[str] = None
 
     def asxml(self) -> ObjectifiedElement:
         return E.source(**{field: getattr(self, field)

--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -477,6 +477,33 @@ class TestRequest(OscTest):
             )
 
         with self.subTest(
+            "XML content, source with optional repository"
+        ), mock.patch.object(
+            self.osc.session, "send", return_value=mock_response
+        ) as mock_session:
+            self.osc.requests.create(
+                actions=[
+                    Action(
+                        type=ActionType.RELEASE,
+                        source=Source(
+                            project="Foo:Bar", package="p", repository="images"
+                        ),
+                        target=Target(project="Baz:Qux"),
+                    )
+                ]
+            )
+            self.assertEqual(
+                mock_session.call_args[0][0].body,
+                b"<?xml version='1.0' encoding='utf-8'?>\n"
+                b"<request>"
+                b'<action type="release">'
+                b'<target project="Baz:Qux"/>'
+                b'<source project="Foo:Bar" package="p" repository="images"/>'
+                b"</action>"
+                b"</request>",
+            )
+
+        with self.subTest(
             "XML content, target with optional repository"
         ), mock.patch.object(
             self.osc.session, "send", return_value=mock_response


### PR DESCRIPTION
closes #190 