### PR TITLE
Request review: always default to state="new", because OBS considers it a mandatory attribute (fixes #194)

### DIFF
--- a/osctiny/models/request.py
+++ b/osctiny/models/request.py
@@ -103,4 +103,7 @@ class Review(typing.NamedTuple):
     name: str
 
     def asxml(self) -> ObjectifiedElement:
-        return E.review(**{self.by.value: self.name})
+        # The state attribute is mandatory, despite its value being ignored by
+        # OBS and always reset to "new"
+        # (see https://github.com/openSUSE/open-build-service/issues/17028).
+        return E.review(**{self.by.value: self.name, "state": "new"})

--- a/osctiny/tests/test_requests.py
+++ b/osctiny/tests/test_requests.py
@@ -414,8 +414,8 @@ class TestRequest(OscTest):
                 b'<action type="delete">'
                 b'<target project="Foo:Bar:Factory" package="hello-world"/>'
                 b'</action>'
-                b'<review by_user="nemo"/>'
-                b'<review by_group="superusers"/>'
+                b'<review by_user="nemo" state="new"/>'
+                b'<review by_group="superusers" state="new"/>'
                 b'</request>'
             )
 


### PR DESCRIPTION
closes #194 