### PR TITLE
Fix: in changelog packager must contain email address

### DIFF
--- a/auto_release_obs.py
+++ b/auto_release_obs.py
@@ -76,11 +76,10 @@ class Obs:
         response = self.osc.packages.get_file(self.project, self.package,
                                               f"{self.package}.changes")
         response.encoding = 'utf-8'
-        content = f"- Release {self.release_name}\n"
-        for line in self.release_body.split("\r\n"):
-            content += f"  {line}\n"
+        lines = [f"  {line}" for line in self.release_body.strip().split("\r\n") if line]
+        content = f"- Release {self.release_name}\n" + "\n".join(lines)
         entry = Entry(
-            packager=self.username,
+            packager=f"{self.username} <maintenance-automation-team@suse.de>",
             content=content,
             timestamp=datetime.now(tz=_UTC())
         )


### PR DESCRIPTION
- Add email address to submitter [^1]
- strip unnecessary blank lines

[^1]: According to this [pattern](https://github.com/openSUSE/obs-service-source_validator/blob/master/helpers/convert_changes_to_rpm_changelog#L45), submitter in changlog must contain email address, otherwise it will fail at `osc service runall source_validator`  then the request will be declined. 