### PR TITLE
ci: Use container images for pre 3.8 pythons

### DIFF
--- a/.github/workflows/default.yml
+++ b/.github/workflows/default.yml
@@ -4,16 +4,13 @@ on: [push, pull_request]
 
 jobs:
   test_pre38:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
+    container: "docker.io/library/python:${{ matrix.python-version }}"
     strategy:
       matrix:
         python-version: [ 3.6, 3.7 ]
     steps:
       - uses: actions/checkout@v4
-      - name: Set up Python ${{ matrix.python-version }}
-        uses: actions/setup-python@v5
-        with:
-          python-version: ${{ matrix.python-version }}
       - name: Cache pip
         uses: actions/cache@v4
         with:


### PR DESCRIPTION
ubuntu-20.04 is deprecated and no longer available, hence we have to rely on deprecated but still present container images